### PR TITLE
Compile warnings

### DIFF
--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -142,8 +142,8 @@ int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, const uint8_t *data,
 
 	/* Send frame */
 	while (write(sock, &frame, sizeof(frame)) != sizeof(frame)) {
-		const unsigned timeout_us = 10000; // 10 ms
-		const unsigned retry_us = 1;
+		const int timeout_us = 10000; // 10 ms
+		const int retry_us = 1;
 		if (++tries < (timeout_us / retry_us) && errno == ENOBUFS) {
 			/* Wait and try again */
 			usleep(retry_us);

--- a/src/interfaces/csp_if_nng.c
+++ b/src/interfaces/csp_if_nng.c
@@ -5,6 +5,7 @@
 #include <nng/nng.h>
 
 #include "csp/csp.h"
+#include "csp/csp_endian.h"
 #include "csp/csp_interface.h"
 #include "csp/interfaces/csp_if_nng.h"
 


### PR DESCRIPTION
Fixed two instances of compilation warnings:
- Missing header file include in NNH interface.
- Mismatched signedness in integer comparison in socketcan timeout 