### PR TITLE
KISS baud and transmit fix

### DIFF
--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -203,6 +203,7 @@ int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callbac
 		case 3000000: break;
 		case 3500000: break;
 		case 4000000: break;
+		case 6250000: break;
 		default:
 			csp_log_warn("%s: Using non-default baudrate: %u", __FUNCTION__, conf->baudrate);
 	}

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -77,7 +77,7 @@ int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 			buffer_length += sizeof(esc_end);
 		}
 		else if (*data == FESC) { // Escape FESC character
-			memcpy(&buffer[buffer_length], esc_end, sizeof(esc_esc));
+			memcpy(&buffer[buffer_length], esc_esc, sizeof(esc_esc));
 			buffer_length += sizeof(esc_esc);
 		}
 		else { // Add normal data to buffer


### PR DESCRIPTION
**Summary of the pull request for the changelog**
- Rewrite KISS interface transmission function to be more efficient
- Add support for custom baudrates for serial devices on Linux

**What issues are related to this pull request?**
This pull request makes changes in libcsp KISS interface and drivers which enables it to work over higher baudrates, as described in [hypso-sw issue 796](https://github.com/NTNU-SmallSat-Lab/hypso-sw/issues/796). 
This pull request also closes [hypso-sw issue 821](https://github.com/NTNU-SmallSat-Lab/hypso-sw/issues/821).

**What does your pull request address?**
A more in depth explanation

This pull request does two very specific things:
- It restructures the way the CSP KISS interface sends data. Currently the transmit function that is called when transmitting data over KISS takes each byte in a packet and sends it to the transmit function in the driver. This makes it easier to add escape characters to the transmission, but it is also inefficient as it calls the drivers transmit function a lot of times. This pull request rewrites the interface transmit function so that it writes all the data and escape characters to an output buffer, and sends the full output buffer to the driver transmit function once.
This change made KISS communication over higher speed much more stable.
- The pull request also add support for non-default baudrates, by changing the Linux serial initialization from [termios](https://man7.org/linux/man-pages/man3/termios.3.html) to [ioctl_tty](https://man7.org/linux/man-pages/man4/tty_ioctl.4.html). The function of these should be almost identical, and the serial device should behave the same way as previously, only with the support for custom baudrates. 

**Describe potential caveats of the pull request, if any**
A potential caveat for the change from termios to ioctl_tty is portability. Quote from [ioctl_tty man page](https://man7.org/linux/man-pages/man4/tty_ioctl.4.html):
> Use of ioctl() makes for nonportable programs.  Use the POSIX
       interface described in [termios(3)](https://man7.org/linux/man-pages/man3/termios.3.html) whenever possible.

Since this change is done in the linux usart driver, I would argue that portability is not a problem. This should be supported on Linux systems. More importantly, this works fine on the hardware we currently use in the HYPSO project.

A potential caveat for transmitting all the bytes in one go is the possibility of RX buffers on the receive side being too small, and then not being able to receive the full message. I believe this should be controlled either by the lower level drivers or the mtu option that can be set so I don't consider this a problem. It has not been a problem with the hardware we use in the HYPSO project.

**How to test the pull request**
- Build relevant applications with this libcsp
- Test KISS communication over non-default baudrates